### PR TITLE
fix: BadTomlData on fresh install

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub(crate) enum ViewerType {
 
 /// Groups data passed by the user in the config file.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct Config {
     /// Path to the vault to index.
     pub(crate) vault_path: Option<path::PathBuf>,


### PR DESCRIPTION
Hello there!

Thanks for creating this wonderful tool! I was actually working on something like that on my side but Rucola is perfect! :).

I ended up with a tiny bug on a fresh install (without any configuration file or anything). 

`BadTomlData` error on the launch. I tried to install the binary from Arch package and also compile Rucola from source but the result was the same.

After digging a bit the code, apparently confy require some extra configuration (see https://github.com/rust-cli/confy/issues/34). 

Here a tiny pull request. Please do not hesitate to tell me if I'm wrong or if you know a better way to fix it. 