### PR TITLE
fix: new note creates markdown without valid title

### DIFF
--- a/src/io/file_manager.rs
+++ b/src/io/file_manager.rs
@@ -228,7 +228,7 @@ impl FileManager {
         // Write an preliminary input, so the file isn't empty (messed with XDG for some reason).
         write!(
             file,
-            "#{}",
+            "# {}",
             path.file_stem()
                 .map(|fs| fs.to_string_lossy().to_string())
                 .unwrap_or_else(|| "note".to_owned())


### PR DESCRIPTION
:wave: Hello,

I've discovered an issue with Rucola's note creation functionality. When creating a new note and entering a title in the form, the title is incorrectly formatted in the markdown file.

For example, if I create a note with the title "My wonderful Title", Rucola generates a file with the first line as `#My wonderful Title`. This presents two problems:

* It's not properly formatted as a Markdown Heading 1 (which requires a space after the # symbol)
* "My" is incorrectly interpreted as a tag rather than the beginning of the title

While many users may prefer creating notes directly in their editors rather than through Rucola's interface, I believe this behavior should be corrected for those who do use the built-in functionality. :) 

I've submitted a pull request that fixes this issue by properly formatting the title as a standard Markdown Heading 1 with appropriate spacing, preventing unintended tag creation. 

Let me know if I've overlooked anything. :) 

Thank you!