### PR TITLE
Add unicode normalization to name_to_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "testdir",
  "thiserror 2.0.12",
  "tui-textarea",
+ "unicode-normalization",
  "yaml-rust",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "^1.0"
 directories = "^6.0"
 confy = "^1.0"
+unicode-normalization = "0.1.24"
 
 [target.'cfg(unix)'.dependencies]
 expanduser = "^1.2"


### PR DESCRIPTION
### Changes
This makes sure unicode characters are normalized every time the `name_to_id` function is called. It does introduce the [unicode-normalization crate](https://crates.io/crates/unicode-normalization) as a dependency, though it is worth it in my opinion to potentially save other users some headaches/frustration. As far as I understand, changing that function should be enough to ensure links continuing to work across different uft8 formats. I also adjusted the docs and added a few simple tests. (on a side note, the `test_watcher_rename` test fails for me on macOS, but it did/does so on the main branch as well)

### Why/Background?
There are unicode characters that can be represented as [composed or decomposed](https://en.wikipedia.org/wiki/Precomposed_character#Comparing_precomposed_and_decomposed_characters) form.

Per se it doesn't matter which form is chosen as long as it is consistent within the system, so the encoding for the file name is the same as for the content, i.e. the links. If those two encoding formats diverge links end up breaking.
This may be more common than it sounds, as services syncing to other systems may change the filename encoding format, e.g. [syncthing does so by default](https://docs.syncthing.net/advanced/folder-autonormalize.html)).

I noticed I kept getting "broken links", though inspecting them they looked fine. Deleting and re-entering the link (seemingly) identically fixed it. Though eventually I figured why this was happening, it did annoy me for a good while that my links kept breaking.

--- 

Even though it is a bit of an edge case, is not exactly a bug with rucola but usually due to some third party service touch files and probably only affects a very small set of users, I think not having to worry about character encoding too much is probably a good thing.



(P.S. thanks for the cool tool, I've really been enjoying rucola for managing my notes!)