### PR TITLE
Add "Last Modified" sorting option and default sorting configuration

### DIFF
--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -23,6 +23,15 @@ theme = "default_dark"
 stats_show = "Relevant"   # Show global stats if there is no filter applied and local if there is.
 
 
+# Default sorting mode for notes on the main select screen.
+# Available options: "Name", "Words", "Chars", "GlobalOutLinks", "LocalOutLinks", 
+# "GlobalInLinks", "LocalInLinks", "Score", "Broken", "LastModified"
+default_sorting = "Name"
+
+# Default sorting direction (true for ascending, false for descending)
+default_sorting_asc = true
+
+
 # The default editor to use for editing notes.
 # The first element is the command, the others will be used as positional arguments.
 # An element "%p" will be replaced by the file path of the note when calling this command.

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,6 +107,8 @@ impl App {
                     builder.clone(),
                     styles,
                     config.stats_show,
+                    config.default_sorting,
+                    config.default_sorting_asc,
                 ),
                 display: None,
                 display_stack: Vec::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path};
 
-use crate::{error, ui};
+use crate::{data, error, ui};
 
 /// The file format a viewer expects.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -28,6 +28,10 @@ pub struct Config {
     pub(crate) theme: String,
     /// When to show the global stats area
     pub(crate) stats_show: ui::screen::StatsShow,
+    /// Default sorting mode for notes
+    pub(crate) default_sorting: data::SortingMode,
+    /// Default sorting direction (true for ascending, false for descending)
+    pub(crate) default_sorting_asc: bool,
     /// The editor to use for notes.
     pub(crate) editor: Option<Vec<String>>,
     /// Main viewer to inspect rendered notes.
@@ -58,6 +62,8 @@ impl Default for Config {
             default_extension: String::from("md"),
             theme: "default_dark".to_string(),
             stats_show: ui::screen::StatsShow::Both,
+            default_sorting: data::SortingMode::Name,
+            default_sorting_asc: true,
             editor: None,
             viewer_type: Some(ViewerType::Html),
             viewer: Some(vec![String::from("firefox"), String::from("%p")]),

--- a/src/data/note_statistics.rs
+++ b/src/data/note_statistics.rs
@@ -55,7 +55,7 @@ impl NoteEnvStatistics {
 }
 
 /// Describes the current sorting mode of the displayed list.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum SortingMode {
     #[default]
     Name,
@@ -67,6 +67,7 @@ pub enum SortingMode {
     LocalInLinks,
     Score,
     Broken,
+    LastModified,
 }
 
 /// A data struct containing statistical information about a (subset of a) user's notes.
@@ -235,6 +236,16 @@ impl EnvironmentStats {
                         SortingMode::LocalInLinks => env_stats.inlinks_local,
                         SortingMode::Score => env_stats.match_score as usize,
                         SortingMode::Broken => env_stats.broken_links,
+                        SortingMode::LastModified => {
+                            // Get the file's modification time as seconds since epoch
+                            note.path
+                                .metadata()
+                                .and_then(|m| m.modified())
+                                .ok()
+                                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                                .map(|d| d.as_secs() as usize)
+                                .unwrap_or(0)
+                        }
                     }
                 } else {
                     0

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -92,6 +92,8 @@ impl SelectScreen {
         builder: io::HtmlBuilder,
         styles: ui::UiStyles,
         stats_show: StatsShow,
+        default_sorting: data::SortingMode,
+        default_sorting_asc: bool,
     ) -> Self {
         let mut res = Self {
             local_stats: data::EnvironmentStats::new_with_filter(&index, data::Filter::default()),
@@ -105,13 +107,14 @@ impl SelectScreen {
             name_area: TextArea::default(),
             mode: SelectMode::Select,
             any_conditions: false,
-            sorting: data::SortingMode::Name,
-            sorting_asc: true,
+            sorting: default_sorting,
+            sorting_asc: default_sorting_asc,
             selected: 0,
             stats_show,
         };
 
-        res.local_stats.sort(index, data::SortingMode::Name, true);
+        res.local_stats
+            .sort(index, default_sorting, default_sorting_asc);
 
         res.style_text_area();
 
@@ -553,6 +556,10 @@ impl super::Screen for SelectScreen {
                     self.set_mode_and_maybe_sort(data::SortingMode::Broken, false);
                     self.mode = SelectMode::Select;
                 }
+                KeyCode::Char('t' | 'T') => {
+                    self.set_mode_and_maybe_sort(data::SortingMode::LastModified, false);
+                    self.mode = SelectMode::Select;
+                }
                 KeyCode::Char('r' | 'R') => {
                     self.set_mode_and_maybe_sort(None, !self.sorting_asc);
                     self.mode = SelectMode::Select;
@@ -790,6 +797,7 @@ impl super::Screen for SelectScreen {
                         ("I", "Sort by global inlinks"),
                         ("N", "Sort by local inlinks"),
                         ("B", "Sort by broken links"),
+                        ("T", "Sort by last modified"),
                         ("R", "Reverse sorting"),
                     ]
                 }


### PR DESCRIPTION
Adds the ability to sort notes by last modification time and configure default sorting preferences in `config.toml`

**New Features**
- Sort by Last Modified: Press [T] in sorting menu to sort by file modification time
- Default Sorting Config: Set preferred sorting mode and order in config file

**Issue** #25 