### PR TITLE
Scale help dialog box height with number of dialog rows

### DIFF
--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -918,6 +918,9 @@ impl super::Screen for SelectScreen {
                     ]),
                 ];
 
+                // Pop-up should be as tall as the number of help dialog rows
+                // plus 2 rows for top and bottom border
+                let popup_height = help_rows.len() as u16 + 2;
                 let help_table = Table::new(help_rows, help_widths).column_spacing(1).block(
                     Block::bordered()
                         .title(style::Styled::set_style(
@@ -935,7 +938,7 @@ impl super::Screen for SelectScreen {
 
                 let popup_areas = Layout::vertical([
                     Constraint::Fill(1),
-                    Constraint::Length(10),
+                    Constraint::Length(popup_height),
                     Constraint::Fill(1),
                 ])
                 .split(area);


### PR DESCRIPTION
Thank you for your great work on rucola.

This patch just implements a small fix for the help dialog which is displayed by pressing `?` or `h`. The dialog box height was set to a fixed height of 10 allowing only 8 rows of dialog (+ 2 for borders) to be displayed, which caused some of the help messages, such as the ones documenting the full text search functionality, to not be displayed.