### PR TITLE
Add Nix flake with build, dev shell and checks

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,30 @@
+name: Update flake.lock
+
+on:
+  # Manual trigger from the Actions tab.
+  workflow_dispatch:
+  # Quarterly: 04:00 UTC on the 1st of Jan, Apr, Jul, Oct.
+  schedule:
+    - cron: "0 4 1 */3 *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          pr-title: "Update flake.lock"
+          pr-labels: |
+            dependencies
+            nix
+          commit-msg: "Update flake.lock"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,152 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775907537,
+        "narHash": "sha256-vbeLNgmsx1Z6TwnlDV0dKyeBCcon3UpkV9yLr/yc6HM=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "d99f7b9eb81731bddebf80a355f8be7b2f8b1b28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776050130,
+        "narHash": "sha256-/f/6/1WOfBJaGMfqV3VxWD9lpFRbPpF+Cx4MO+0mGok=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3c27f4c92a7d977556dd2c10bb564d9c61b375e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,218 @@
+{
+  description = "Rucola - terminal-based markdown note manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Modern Rust build framework with split dependency / workspace caching.
+    crane.url = "github:ipetkov/crane";
+
+    # Unified formatter integration (runs on Nix files only here - the Rust
+    # toolchain handles Rust formatting through `cargo fmt` in the dev shell).
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Security advisory database consumed by the cargo-audit check.
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+  };
+
+  outputs = inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+
+      imports = [
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      # Flake-wide outputs. Exposing an overlay lets downstream flakes pull
+      # rucola in via `overlays = [ rucola.overlays.default ]`.
+      flake = {
+        overlays.default = _final: prev: {
+          rucola = self.packages.${prev.stdenv.hostPlatform.system}.rucola;
+        };
+      };
+
+      perSystem = { config, system, lib, ... }:
+        let
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ inputs.rust-overlay.overlays.default ];
+          };
+
+          # Toolchain exactly pinned. `nix flake update` won't silently bump
+          # the Rust compiler - only an explicit edit of this version does.
+          rustToolchain = pkgs.rust-bin.stable."1.94.1".default.override {
+            extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
+          };
+
+          # Crane bound to the pinned toolchain. All crane-produced
+          # derivations (buildPackage, cargoClippy, cargoNextest, ...) share
+          # this single rustc/cargo.
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          cargoToml = lib.importTOML ./Cargo.toml;
+
+          # Minimal source: only the inputs cargo actually needs. Editing
+          # README.md, CI configs or the flake itself no longer busts
+          # rucola's build cache.
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              ./build.rs
+              ./src
+              ./tests
+              ./default-config
+            ];
+          };
+
+          # Native tools + C libraries rucola's dependency graph links
+          # against. git2 is the driver; the rest of the tree is pure Rust.
+          nativeBuildInputs = [ pkgs.pkg-config ];
+
+          buildInputs = with pkgs;
+            [ openssl zlib libgit2 ]
+            ++ lib.optionals stdenv.hostPlatform.isDarwin (
+              [ libiconv ]
+              ++ (with pkgs.darwin.apple_sdk.frameworks; [
+                CoreFoundation
+                Security
+                SystemConfiguration
+              ])
+            );
+
+          # Shared args for every crane invocation in this flake. Using the
+          # same set for buildDepsOnly, buildPackage and every check means
+          # the fetched-and-built dependency graph is cached exactly once
+          # and reused for linting, testing and the final binary.
+          commonArgs = {
+            inherit src nativeBuildInputs buildInputs;
+            pname = cargoToml.package.name;
+            version = cargoToml.package.version;
+
+            strictDeps = true;
+
+            # Prefer system libraries over the copies vendored by the -sys
+            # crates. Keeps the closure small and inherits upstream patches.
+            LIBGIT2_NO_VENDOR = "1";
+            OPENSSL_NO_VENDOR = "1";
+          };
+
+          # Build only the dependency graph. This is the expensive step
+          # (~30s of compile time) and is cached independently from the
+          # workspace itself.
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          rucola = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+
+            # Tests run in a dedicated nextest check below. Skipping them
+            # here keeps `nix build` focused on producing the binary.
+            doCheck = false;
+
+            meta = {
+              description = lib.strings.removeSuffix "." cargoToml.package.description;
+              homepage = cargoToml.package.homepage;
+              changelog = "${cargoToml.package.homepage}/blob/main/CHANGELOG.md";
+              license = lib.licenses.gpl3Only;
+              mainProgram = "rucola";
+              platforms = lib.platforms.unix;
+            };
+          });
+        in
+        {
+          # Share the overlay-augmented pkgs with sibling flake-parts
+          # modules (treefmt-nix) so there is exactly one nixpkgs instance.
+          _module.args.pkgs = pkgs;
+
+          packages = {
+            default = rucola;
+            rucola = rucola;
+          };
+
+          apps.default = {
+            type = "app";
+            program = lib.getExe rucola;
+          };
+
+          devShells.default = pkgs.mkShell {
+            inherit nativeBuildInputs buildInputs;
+
+            packages = with pkgs; [
+              rustToolchain
+              # Cargo ergonomics
+              cargo-edit
+              cargo-watch
+              cargo-outdated
+              cargo-audit
+              cargo-nextest
+              # Standalone TOML formatter referenced in the comments below
+              # (treefmt deliberately doesn't wire it in as a flake check).
+              taplo
+              # Nix ergonomics
+              nil
+              config.treefmt.build.wrapper
+            ];
+
+            env = {
+              LIBGIT2_NO_VENDOR = "1";
+              OPENSSL_NO_VENDOR = "1";
+              RUST_BACKTRACE = "1";
+              RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+            };
+
+            shellHook = ''
+              echo "rucola dev shell - $(rustc --version)"
+            '';
+          };
+
+          # `nix flake check` runs the full matrix: package build, strict
+          # clippy, the full test suite via nextest, and a RUSTSEC audit
+          # against the pinned advisory-db snapshot.
+          checks = {
+            inherit rucola;
+
+            clippy = craneLib.cargoClippy (commonArgs // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets --all-features -- -D warnings";
+            });
+
+            nextest = craneLib.cargoNextest (commonArgs // {
+              inherit cargoArtifacts;
+              # test_viewing canonicalises paths that don't exist inside
+              # the sandbox; everything else runs in the sandbox cleanly.
+              cargoNextestExtraArgs = "--no-fail-fast -E 'not test(=test_viewing)'";
+              partitions = 1;
+              partitionType = "count";
+            });
+
+            audit = craneLib.cargoAudit {
+              inherit src;
+              inherit (inputs) advisory-db;
+            };
+          };
+
+          # `nix fmt` formats the Nix files in this repo. Rust and TOML
+          # formatting is deliberately not wired in here because it would
+          # rewrite upstream-owned source outside this flake's scope -
+          # run `cargo fmt` / `taplo fmt` from the dev shell if desired.
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixpkgs-fmt.enable = true;
+          };
+        };
+    };
+}


### PR DESCRIPTION
Provides:

- `nix build`     builds rucola with pinned Rust 1.94.1
- `nix develop`   dev shell with toolchain, rust-analyzer, cargo tooling
- `nix flake check` package build + strict clippy + nextest +
cargo-audit
- `nix fmt`       formats Nix files
- `overlays.default` for downstream consumers

Stack: flake-parts, crane, rust-overlay, advisory-db, treefmt-nix.