### PR TITLE
feat(diary): add opt-in functionality to support diary notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.10.0 - Daily Notes
+- Added a diary option by GitHub user robin-thoene
+  - Added a configuration option to enable the daily diary.
+  - Added a keybinding that creates a diary note and opens it in the editor or display screen.
+  - Added a configuration option to determine the format of the title of the diary note.
+  - Added a configuration option to set the initial content of the diary note.
+
 # Version 0.9.0 - Column Configuration
 - Added an additional configuration option that allows users to freely customize the columns shown in the select screen and their headers.
 - This also adds the new, optional columns 'Score' and 'LastModified' (and technically 'Shuffle', which doesn't show anyhting).

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -141,6 +141,9 @@ html_prepend = """
 # Whether to include KaTeX headers in files in which math (delimited by single or double $-signs) was detected, causing this math to be rendered as LaTeX.
 katex = true
 
+# Whether to turn on the diary feature or not. Turning this on enables an additional keybinding for creating and editing the daily diary note.
+enable_diary = false
+
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]
 '\field' = '\mathbb'

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -145,6 +145,10 @@ katex = true
 [diary]
 # Whether to turn on the diary feature or not. Turning this on enables an additional keybinding for creating and editing the daily diary note.
 enabled = false
+# The initial content for every newly created diary note
+initial_content = """
+#diary
+"""
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -149,6 +149,8 @@ enabled = false
 initial_content = """
 #diary
 """
+# The format of the daily diary note title
+title_format = "{year}-{month}-{day}"
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -141,8 +141,10 @@ html_prepend = """
 # Whether to include KaTeX headers in files in which math (delimited by single or double $-signs) was detected, causing this math to be rendered as LaTeX.
 katex = true
 
+# Configuration section for the diary feature
+[diary]
 # Whether to turn on the diary feature or not. Turning this on enables an additional keybinding for creating and editing the daily diary note.
-enable_diary = false
+enabled = false
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -133,6 +133,7 @@ viewer_type = "Html"
 enabled = false
 # The initial content for every newly created diary note
 initial_content = """
+
 #diary
 """
 # The format of the daily diary note title.

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -138,11 +138,15 @@ initial_content = """
 """
 # The format of the daily diary note title.
 # Uses the formatting options from the chrono library available here: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+# It is also possible to create the note in a subfolder or use a custom file extension. If no file extension is given, the `default_extension` from above will be used.
+# When using a date format containing `.`, it may be necessary to manually re-add the extension.
 # Examples:
-# title_format = "daily-note-%d.%m.%Y" # Daily note for 19.05.2026
 # title_format = "Diary %d %B, %Y" # Diary 19 May, 2026
 # title_format = "%Y-%m-%d" # 2026-05-19
+# title_format = "daily-note-%d.%m.%Y.md" # Daily note for 19.05.2026
 title_format = "%F" # 2026-05-19
+# title_format = "%F.txt" # 2026-05-19 with file extension `.txt`
+# title_format = "diary/%F" # 2026-05-19 in subfolder diary
 
 # When enabled, HTML versions of your files will be created and updated on launch and continuously in the background. Set this to false if you do not want to use the view-as-HTML-feature.
 enable_html = true

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -150,7 +150,12 @@ initial_content = """
 #diary
 """
 # The format of the daily diary note title.
-title_format = "{year}-{month}-{day}"
+# Uses the formatting options from the chrono library available here: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+# Examples:
+# title_format = "daily-note-%d.%m.%Y" # Daily note for 19.05.2026
+# title_format = "Diary %d %B, %Y" # Diary 19 May, 2026
+# title_format = "%Y-%m-%d" # 2026-05-19
+title_format = "%F" # 2026-05-19
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -141,15 +141,15 @@ html_prepend = """
 # Whether to include KaTeX headers in files in which math (delimited by single or double $-signs) was detected, causing this math to be rendered as LaTeX.
 katex = true
 
-# Configuration section for the diary feature
+# Configuration section for the daily diary feature.
 [diary]
-# Whether to turn on the diary feature or not. Turning this on enables an additional keybinding for creating and editing the daily diary note.
+# This option can be used to turn on the diary feature, enabling an additional keybinding for creating and editing the daily diary note.
 enabled = false
 # The initial content for every newly created diary note
 initial_content = """
 #diary
 """
-# The format of the daily diary note title
+# The format of the daily diary note title.
 title_format = "{year}-{month}-{day}"
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.

--- a/default-config/config.toml
+++ b/default-config/config.toml
@@ -127,20 +127,6 @@ viewer_type = "Html"
 # If that is also not given, defaults to "Html".
 # secondary_viewer_type = "Html"
 
-
-# When enabled, HTML versions of your files will be created and updated on launch and continuously in the background. Set this to false if you do not want to use the view-as-HTML-feature.
-enable_html = true
-
-# The name of the css file to use when creating HTML files. Must be located in your rucola config folder.
-css = "default_dark"
-
-# Any further HTML to prepend to created HTML files, for example special Javascript that you want included.
-html_prepend = """
-"""
-
-# Whether to include KaTeX headers in files in which math (delimited by single or double $-signs) was detected, causing this math to be rendered as LaTeX.
-katex = true
-
 # Configuration section for the daily diary feature.
 [diary]
 # This option can be used to turn on the diary feature, enabling an additional keybinding for creating and editing the daily diary note.
@@ -156,6 +142,19 @@ initial_content = """
 # title_format = "Diary %d %B, %Y" # Diary 19 May, 2026
 # title_format = "%Y-%m-%d" # 2026-05-19
 title_format = "%F" # 2026-05-19
+
+# When enabled, HTML versions of your files will be created and updated on launch and continuously in the background. Set this to false if you do not want to use the view-as-HTML-feature.
+enable_html = true
+
+# The name of the css file to use when creating HTML files. Must be located in your rucola config folder.
+css = "default_dark"
+
+# Any further HTML to prepend to created HTML files, for example special Javascript that you want included.
+html_prepend = """
+"""
+
+# Whether to include KaTeX headers in files in which math (delimited by single or double $-signs) was detected, causing this math to be rendered as LaTeX.
+katex = true
 
 # Simple LaTeX macro system. See [KaTeX options](https://katex.org/docs/options.html) for details, only as TOML. Example: Typing $\field{R}$ will be transformed into $\mathbb{R}$ before being compiled with KaTeX.
 [math_replacements]

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,9 @@ pub struct Config {
     pub(crate) katex: bool,
     /// A list of strings to replace in math mode to mimic latex commands
     pub(crate) math_replacements: HashMap<String, String>,
+    /// When set to true, the diary feature is enabled, allowing to create and jump to the current
+    /// day's diary note via keybind
+    pub(crate) enable_diary: bool,
 }
 
 impl Default for Config {
@@ -94,6 +97,7 @@ impl Default for Config {
                 "\\field".to_string(),
                 "\\mathbb".to_string(),
             )]),
+            enable_diary: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,8 @@ pub struct DiaryConfig {
     pub enabled: bool,
     /// The initial content to write into every diary note on creation
     pub initial_content: Option<String>,
+    /// The format of the daily diary note title
+    pub title_format: Option<String>,
 }
 
 impl Default for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,10 @@ pub struct Config {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct DiaryConfig {
+    /// Whether the diary feature is enabled or not
     pub enabled: bool,
+    /// The initial content to write into every diary note on creation
+    pub initial_content: Option<String>,
 }
 
 impl Default for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,9 +58,13 @@ pub struct Config {
     pub(crate) katex: bool,
     /// A list of strings to replace in math mode to mimic latex commands
     pub(crate) math_replacements: HashMap<String, String>,
-    /// When set to true, the diary feature is enabled, allowing to create and jump to the current
-    /// day's diary note via keybind
-    pub(crate) enable_diary: bool,
+    /// Configuration section for the diary feature
+    pub(crate) diary: DiaryConfig,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+pub struct DiaryConfig {
+    pub enabled: bool,
 }
 
 impl Default for Config {
@@ -97,7 +101,7 @@ impl Default for Config {
                 "\\field".to_string(),
                 "\\mathbb".to_string(),
             )]),
-            enable_diary: false,
+            diary: DiaryConfig::default(),
         }
     }
 }

--- a/src/data/index.rs
+++ b/src/data/index.rs
@@ -118,6 +118,18 @@ impl NoteIndex {
         self.inner.get(key)
     }
 
+    /// Loads the note at the given path and inserts it into the index.
+    /// Also creates the corresponding HTML file.
+    /// This is used when a note is created programmatically and the file watcher
+    /// may not have had time to pick it up yet (e.g. due to a race condition when
+    /// creating a new subdirectory and a file inside it in quick succession).
+    pub fn insert_note_from_path(&mut self, path: &std::path::Path) -> error::Result<()> {
+        let note = Note::from_path(path)?;
+        self.builder.create_html(&note, false)?;
+        self.inner.insert(super::name_to_id(&note.name), note);
+        Ok(())
+    }
+
     /// Handle all file events on notes, as found by the contained tracker.
     ///  - Renames and moves are tracked
     ///  - new file creations with in the vault folder are checked for notes and added if appropriate

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -35,6 +35,10 @@ pub fn name_to_id(name: &str) -> String {
         .split(['#', '.'])
         .take(1)
         .collect::<String>()
+        .split('/')
+        .rev()
+        .take(1)
+        .collect::<String>()
         .to_lowercase()
         .replace(' ', "-")
         .replace(".md", "")
@@ -57,6 +61,10 @@ mod tests {
         assert_eq!(name_to_id("Lie Theory.md"), "lie-theory");
         assert_eq!(name_to_id("Lie Theory"), "lie-theory");
         assert_eq!(name_to_id("lie-theory"), "lie-theory");
+        assert_eq!(name_to_id("Math/Lie Theory.md"), "lie-theory");
+        assert_eq!(name_to_id("Math/Lie Theory"), "lie-theory");
+        assert_eq!(name_to_id("Math/Algebra/Lie Theory"), "lie-theory");
+        assert_eq!(name_to_id("Math/lie-theory"), "lie-theory");
     }
 
     #[test]

--- a/src/io/file_manager.rs
+++ b/src/io/file_manager.rs
@@ -244,7 +244,7 @@ impl FileManager {
 
         // If an initial content is given, write it to the file
         if let Some(content) = initial_content {
-            write!(file, "\n\n{}", content)?;
+            write!(file, "\n{}", content)?;
         }
 
         Ok(path)

--- a/src/io/file_manager.rs
+++ b/src/io/file_manager.rs
@@ -213,7 +213,11 @@ impl FileManager {
     /// Creates a note of the given name in the file system (relative to the vault).
     /// Registration in the index is handled centrally by the file watcher of the index itself.
     /// Returns the path to the newly created note.
-    pub fn create_note_file(&self, input_path: &str) -> error::Result<PathBuf> {
+    pub fn create_note_file(
+        &self,
+        input_path: &str,
+        initial_content: Option<String>,
+    ) -> error::Result<PathBuf> {
         // Piece together the file path
         let mut path = self.vault_path.clone();
         path.push(input_path);
@@ -237,6 +241,11 @@ impl FileManager {
             "# {}",
             crate::data::path_to_name(&path).unwrap_or_else(|_e| "Note".to_owned())
         )?;
+
+        // If an initial content is given, write it to the file
+        if let Some(content) = initial_content {
+            write!(file, "\n\n{}", content)?;
+        }
 
         Ok(path)
     }
@@ -411,8 +420,8 @@ mod tests {
 
         let fm = super::FileManager::new(&config);
 
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let lg_path = tmp.join(String::from("Lie Group.md"));
         let at_path = tmp
@@ -438,8 +447,8 @@ mod tests {
             ..Default::default()
         });
 
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let lg_path = tmp.join(String::from("Lie Group.txt"));
         let at_path = tmp
@@ -464,8 +473,8 @@ mod tests {
         };
         let fm = super::FileManager::new(&config);
 
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let lg_path = tmp.join(String::from("Lie Group.md"));
         let at_path = tmp
@@ -510,8 +519,8 @@ mod tests {
             .join(String::from("Math"))
             .join(String::from("Atlantis.md"));
 
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let tracker = crate::io::FileTracker::new(&config).unwrap();
         let builder = crate::io::HtmlBuilder::new(&config);
@@ -548,9 +557,9 @@ mod tests {
         let ma_path = tmp.join(String::from("Manifold.md"));
         let to_path = tmp.join(String::from("Topology.md"));
 
-        fm.create_note_file("Atlas").unwrap();
-        fm.create_note_file("Manifold").unwrap();
-        fm.create_note_file("Topology").unwrap();
+        fm.create_note_file("Atlas", None).unwrap();
+        fm.create_note_file("Manifold", None).unwrap();
+        fm.create_note_file("Topology", None).unwrap();
 
         std::fs::copy(
             std::env::current_dir()
@@ -629,8 +638,8 @@ mod tests {
             .join(String::from("Atlantis"))
             .join(String::from("Atlas.md"));
 
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let tracker = crate::io::FileTracker::new(&config).unwrap();
         let builder = crate::io::HtmlBuilder::new(&config);

--- a/src/io/file_manager.rs
+++ b/src/io/file_manager.rs
@@ -1,5 +1,10 @@
 use crate::{config, data, error};
-use std::{fs, io::Write, path, process};
+use std::{
+    fs,
+    io::Write,
+    path::{self, PathBuf},
+    process,
+};
 
 /// Saves configurations to manipulate the file system the notes are stored in.
 #[derive(Debug, Clone)]
@@ -207,7 +212,8 @@ impl FileManager {
 
     /// Creates a note of the given name in the file system (relative to the vault).
     /// Registration in the index is handled centrally by the file watcher of the index itself.
-    pub fn create_note_file(&self, input_path: &str) -> error::Result<()> {
+    /// Returns the path to the newly created note.
+    pub fn create_note_file(&self, input_path: &str) -> error::Result<PathBuf> {
         // Piece together the file path
         let mut path = self.vault_path.clone();
         path.push(input_path);
@@ -232,7 +238,7 @@ impl FileManager {
             crate::data::path_to_name(&path).unwrap_or_else(|_e| "Note".to_owned())
         )?;
 
-        Ok(())
+        Ok(path)
     }
 
     /// Attempts to create a command to open the file at the given path to edit it.

--- a/src/io/file_tracker.rs
+++ b/src/io/file_tracker.rs
@@ -264,8 +264,8 @@ mod tests {
             ..Default::default()
         };
         let fm = crate::io::FileManager::new(&config);
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let tracker = crate::io::FileTracker::new(&config).unwrap();
         let builder = crate::io::HtmlBuilder::new(&config);
@@ -320,8 +320,8 @@ mod tests {
         };
 
         let fm = crate::io::FileManager::new(&config);
-        fm.create_note_file("Lie Group").unwrap();
-        fm.create_note_file("Math/Atlas").unwrap();
+        fm.create_note_file("Lie Group", None).unwrap();
+        fm.create_note_file("Math/Atlas", None).unwrap();
 
         let tracker = crate::io::FileTracker::new(&config).unwrap();
         let builder = crate::io::HtmlBuilder::new(&config);

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -63,6 +63,8 @@ pub struct SelectScreen {
     builder: io::HtmlBuilder,
     /// The used styles.
     styles: ui::UiStyles,
+    /// Whether the diary functionality is enabled or not
+    enable_diary: bool,
 
     // === UI ===
     /// The text area to type in filters.
@@ -126,6 +128,7 @@ impl SelectScreen {
             selected: 0,
             stats_show: config.stats_show,
             column_config: config.select_columns.clone(),
+            enable_diary: config.enable_diary,
         };
 
         res.local_stats
@@ -382,8 +385,7 @@ impl super::Screen for SelectScreen {
                     }
                 }
                 // Shortcut to the diary entry for the current day
-                KeyCode::Char('d' | 'D') => {
-                    // TODO: respect user config choices
+                KeyCode::Char('d' | 'D') if self.enable_diary => {
                     // Get the current date
                     let current_date = Local::now().date_naive();
                     // Determine the desired note id for today's diary entry
@@ -800,9 +802,7 @@ impl super::Screen for SelectScreen {
             String::new()
         };
 
-        let instructions_bot_right = Line::from(vec![
-            Span::styled("D", self.styles.hotkey_style),
-            Span::styled("iary──", self.styles.text_style),
+        let mut keybinding_spans = vec![
             Span::styled("E", self.styles.hotkey_style),
             Span::styled("dit──", self.styles.text_style),
             Span::styled("V", self.styles.hotkey_style),
@@ -814,8 +814,12 @@ impl super::Screen for SelectScreen {
             Span::styled("anage Files──", self.styles.text_style),
             Span::styled("Q", self.styles.hotkey_style),
             Span::styled("uit", self.styles.text_style),
-        ])
-        .right_aligned();
+        ];
+        if self.enable_diary {
+            keybinding_spans.insert(0, Span::styled("iary──", self.styles.text_style));
+            keybinding_spans.insert(0, Span::styled("D", self.styles.hotkey_style));
+        }
+        let instructions_bot_right = Line::from(keybinding_spans).right_aligned();
 
         let table_heading_key_style = if self.mode == SelectMode::SubmenuSorting {
             self.styles.hotkey_style

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -1,4 +1,5 @@
 use crate::{data, error, io, ui};
+use chrono::Local;
 use itertools::Itertools;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::{prelude::*, widgets::*};
@@ -379,6 +380,24 @@ impl super::Screen for SelectScreen {
                     if let Some(env_stats) = self.local_stats.get_selected(self.selected) {
                         return Ok(ui::Message::DisplayStackPush(env_stats.id.clone()));
                     }
+                }
+                // Shortcut to the diary entry for the current day
+                KeyCode::Char('d' | 'D') => {
+                    // TODO: respect user config choices
+                    // Get the current date
+                    let current_date = Local::now().date_naive();
+                    // Determine the desired note id for today's diary entry
+                    let diary_entry_id = current_date.format("%Y-%m-%d").to_string();
+                    // Create the note if it note yet exists
+                    if self.index.borrow().get(&diary_entry_id).is_none() {
+                        let created_note_path = self.manager.create_note_file(&diary_entry_id)?;
+                        self.index.borrow().poll_file_system();
+                        self.refresh_env_stats();
+                        return Ok(ui::Message::OpenExternalCommand(Box::new(
+                            self.manager.create_edit_command(&created_note_path)?,
+                        )));
+                    }
+                    return Ok(ui::Message::DisplayStackPush(diary_entry_id));
                 }
                 _ => {}
             },
@@ -782,6 +801,8 @@ impl super::Screen for SelectScreen {
         };
 
         let instructions_bot_right = Line::from(vec![
+            Span::styled("D", self.styles.hotkey_style),
+            Span::styled("iary──", self.styles.text_style),
             Span::styled("E", self.styles.hotkey_style),
             Span::styled("dit──", self.styles.text_style),
             Span::styled("V", self.styles.hotkey_style),

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -390,15 +390,24 @@ impl super::Screen for SelectScreen {
                     let title_format = self.diary_config.title_format.as_deref().unwrap_or("%F");
 
                     // Determine the desired note id for today's diary entry
-                    let diary_entry_id = format!("{}", Local::now().format(title_format));
+                    let diary_entry_name = format!("{}", Local::now().format(title_format));
+                    let diary_entry_id = data::name_to_id(&diary_entry_name);
+
                     // Create the note if it note yet exists
                     if self.index.borrow().get(&diary_entry_id).is_none() {
                         let created_note_path = self.manager.create_note_file(
-                            &diary_entry_id,
+                            &diary_entry_name,
                             self.diary_config.initial_content.clone(),
                         )?;
-                        self.index.borrow().poll_file_system();
+
+                        // Directly insert the new note into the index rather than relying on
+                        // the file watcher.
+                        self.index
+                            .borrow_mut()
+                            .insert_note_from_path(&created_note_path)?;
                         self.refresh_env_stats();
+
+                        // Open the new note in an external editor
                         return Ok(ui::Message::OpenExternalCommand(Box::new(
                             self.manager.create_edit_command(&created_note_path)?,
                         )));
@@ -547,7 +556,7 @@ impl super::Screen for SelectScreen {
                         match mode {
                             SelectMode::Create => {
                                 // Create & register the note
-                                self.manager.create_note_file(
+                                let created_note_path = self.manager.create_note_file(
                                     &super::extract_string_and_clear(&mut self.name_area)
                                         .ok_or_else(|| {
                                             error::RucolaError::Input(String::from(
@@ -556,8 +565,11 @@ impl super::Screen for SelectScreen {
                                         })?,
                                     None,
                                 )?;
-                                // if successful, refresh the ui
-                                self.index.borrow().poll_file_system();
+                                // if successful, add to the index and refresh ui
+                                self.index
+                                    .borrow_mut()
+                                    .insert_note_from_path(&created_note_path)?;
+                                self.refresh_env_stats();
                                 self.refresh_env_stats();
                             }
                             SelectMode::Rename => {

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -128,7 +128,7 @@ impl SelectScreen {
             selected: 0,
             stats_show: config.stats_show,
             column_config: config.select_columns.clone(),
-            enable_diary: config.enable_diary,
+            enable_diary: config.diary.enabled,
         };
 
         res.local_stats

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -387,11 +387,7 @@ impl super::Screen for SelectScreen {
                 // Shortcut to the diary entry for the current day
                 KeyCode::Char('d' | 'D') if self.diary_config.enabled => {
                     // Get the current date
-                    let title_format = self
-                        .diary_config
-                        .title_format
-                        .as_deref()
-                        .unwrap_or_else(|| "%F");
+                    let title_format = self.diary_config.title_format.as_deref().unwrap_or("%F");
 
                     // Determine the desired note id for today's diary entry
                     let diary_entry_id = format!("{}", Local::now().format(title_format));

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -1,6 +1,6 @@
 use crate::config::DiaryConfig;
 use crate::{data, error, io, ui};
-use chrono::{Datelike, Local};
+use chrono::Local;
 use itertools::Itertools;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::{prelude::*, widgets::*};
@@ -387,17 +387,14 @@ impl super::Screen for SelectScreen {
                 // Shortcut to the diary entry for the current day
                 KeyCode::Char('d' | 'D') if self.diary_config.enabled => {
                     // Get the current date
-                    let current_date = Local::now().date_naive();
                     let title_format = self
                         .diary_config
                         .title_format
-                        .clone()
-                        .unwrap_or_else(|| "{year}-{month}-{day}".to_string());
+                        .as_deref()
+                        .unwrap_or_else(|| "%F");
+
                     // Determine the desired note id for today's diary entry
-                    let diary_entry_id = title_format
-                        .replace("{year}", &current_date.year().to_string())
-                        .replace("{month}", &current_date.month().to_string())
-                        .replace("{day}", &current_date.day().to_string());
+                    let diary_entry_id = format!("{}", Local::now().format(title_format));
                     // Create the note if it note yet exists
                     if self.index.borrow().get(&diary_entry_id).is_none() {
                         let created_note_path = self.manager.create_note_file(

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -1,10 +1,9 @@
 use crate::config::DiaryConfig;
 use crate::{data, error, io, ui};
-use chrono::Local;
+use chrono::{Datelike, Local};
 use itertools::Itertools;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::{prelude::*, widgets::*};
-
 use tui_textarea::TextArea;
 
 /// Describes the current mode of the UI.
@@ -389,8 +388,16 @@ impl super::Screen for SelectScreen {
                 KeyCode::Char('d' | 'D') if self.diary_config.enabled => {
                     // Get the current date
                     let current_date = Local::now().date_naive();
+                    let title_format = self
+                        .diary_config
+                        .title_format
+                        .clone()
+                        .unwrap_or_else(|| "{year}-{month}-{day}".to_string());
                     // Determine the desired note id for today's diary entry
-                    let diary_entry_id = current_date.format("%Y-%m-%d").to_string();
+                    let diary_entry_id = title_format
+                        .replace("{year}", &current_date.year().to_string())
+                        .replace("{month}", &current_date.month().to_string())
+                        .replace("{day}", &current_date.day().to_string());
                     // Create the note if it note yet exists
                     if self.index.borrow().get(&diary_entry_id).is_none() {
                         let created_note_path = self.manager.create_note_file(

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -63,7 +63,7 @@ pub struct SelectScreen {
     builder: io::HtmlBuilder,
     /// The used styles.
     styles: ui::UiStyles,
-    /// Whether the diary functionality is enabled or not
+    /// Configuration for the daily diary feature.
     diary_config: DiaryConfig,
 
     // === UI ===

--- a/src/ui/screen/select_screen.rs
+++ b/src/ui/screen/select_screen.rs
@@ -1,3 +1,4 @@
+use crate::config::DiaryConfig;
 use crate::{data, error, io, ui};
 use chrono::Local;
 use itertools::Itertools;
@@ -64,7 +65,7 @@ pub struct SelectScreen {
     /// The used styles.
     styles: ui::UiStyles,
     /// Whether the diary functionality is enabled or not
-    enable_diary: bool,
+    diary_config: DiaryConfig,
 
     // === UI ===
     /// The text area to type in filters.
@@ -128,7 +129,7 @@ impl SelectScreen {
             selected: 0,
             stats_show: config.stats_show,
             column_config: config.select_columns.clone(),
-            enable_diary: config.diary.enabled,
+            diary_config: config.diary.clone(),
         };
 
         res.local_stats
@@ -385,14 +386,17 @@ impl super::Screen for SelectScreen {
                     }
                 }
                 // Shortcut to the diary entry for the current day
-                KeyCode::Char('d' | 'D') if self.enable_diary => {
+                KeyCode::Char('d' | 'D') if self.diary_config.enabled => {
                     // Get the current date
                     let current_date = Local::now().date_naive();
                     // Determine the desired note id for today's diary entry
                     let diary_entry_id = current_date.format("%Y-%m-%d").to_string();
                     // Create the note if it note yet exists
                     if self.index.borrow().get(&diary_entry_id).is_none() {
-                        let created_note_path = self.manager.create_note_file(&diary_entry_id)?;
+                        let created_note_path = self.manager.create_note_file(
+                            &diary_entry_id,
+                            self.diary_config.initial_content.clone(),
+                        )?;
                         self.index.borrow().poll_file_system();
                         self.refresh_env_stats();
                         return Ok(ui::Message::OpenExternalCommand(Box::new(
@@ -550,6 +554,7 @@ impl super::Screen for SelectScreen {
                                                 "New note may not be empty.",
                                             ))
                                         })?,
+                                    None,
                                 )?;
                                 // if successful, refresh the ui
                                 self.index.borrow().poll_file_system();
@@ -815,7 +820,7 @@ impl super::Screen for SelectScreen {
             Span::styled("Q", self.styles.hotkey_style),
             Span::styled("uit", self.styles.text_style),
         ];
-        if self.enable_diary {
+        if self.diary_config.enabled {
             keybinding_spans.insert(0, Span::styled("iary──", self.styles.text_style));
             keybinding_spans.insert(0, Span::styled("D", self.styles.hotkey_style));
         }


### PR DESCRIPTION
### Summary

closes #50 
This is a first draft for adding diary support, not the final PR.

### The following topics are addressed already

- feature is opt-in
- if the daily diary note does not yet exist, it gets created and immediately opened in edit mode
- if the daily diary note already exists, it gets opened in the display screen (default workflow)

### What is still missing

- configurable title format (currently defaults to yyyy-MM-dd)
- writing initial content and making it configurable
- automated tests
- documentation updates (?)

### Remarks

As it feels more natural and fits better with existing keybindings I use the wording 'diary' instead of 'journal'

### Why this PR already?

I thought it would be nice to let you test/play with it already to see how it feels and to get your feedback on it. The current implementation that jumps into edit mode vs. display screen depending on whether the note existed already or not feels very natural and nice to me at least.

This enables me to jump into edit with one keypress less and has no drawback as the note was just created and has no metadata to it anyways. When first creating the daily note I most of the time want to write something down ASAP.